### PR TITLE
Fix issue #2

### DIFF
--- a/mindee/documents/invoice.py
+++ b/mindee/documents/invoice.py
@@ -208,6 +208,8 @@ class Invoice(Document):
         total_vat = 0
         reconstructed_total = 0
         for tax in self.taxes:
+            if tax.value is None or tax.rate is None or tax.rate == 0:
+                return False
             total_vat += tax.value
             reconstructed_total += tax.value + 100 * tax.value / tax.rate
 
@@ -241,6 +243,8 @@ class Invoice(Document):
         total_vat = 0
         reconstructed_total = 0
         for tax in self.taxes:
+            if tax.value is None or tax.rate is None or tax.rate == 0:
+                return False
             total_vat += tax.value
             reconstructed_total += 100 * tax.value / tax.rate
 

--- a/mindee/documents/receipt.py
+++ b/mindee/documents/receipt.py
@@ -189,7 +189,7 @@ class Receipt(Document):
         total_vat = 0
         reconstructed_total = 0
         for tax in self.taxes:
-            if tax.value is None or tax.rate is None:
+            if tax.value is None or tax.rate is None or tax.rate == 0:
                 return False
             total_vat += tax.value
             reconstructed_total += tax.value + 100 * tax.value / tax.rate

--- a/tests/documents/test_invoice.py
+++ b/tests/documents/test_invoice.py
@@ -290,3 +290,21 @@ def test_empty_object_works():
     invoice = Invoice()
     assert invoice.total_tax.value is None
 
+def test_null_tax_rates_dont_raise():
+    invoice = Invoice(
+        locale="fr",
+        total_incl=12,
+        total_excl=15,
+        invoice_date="2018-12-21",
+        invoice_number="001",
+        due_date="2019-01-01",
+        taxes={(1, 0), (2, 20)},
+        supplier="Amazon",
+        payment_details="1231456498799765",
+        company_number="asdqsdae",
+        vat_number="1231231232",
+        orientation=0,
+        total_tax=3
+    )
+    assert invoice.checklist["taxes_match_total_incl"] is False
+    assert invoice.checklist["taxes_match_total_excl"] is False

--- a/tests/documents/test_invoice.py
+++ b/tests/documents/test_invoice.py
@@ -290,6 +290,7 @@ def test_empty_object_works():
     invoice = Invoice()
     assert invoice.total_tax.value is None
 
+
 def test_null_tax_rates_dont_raise():
     invoice = Invoice(
         locale="fr",

--- a/tests/documents/test_receipt.py
+++ b/tests/documents/test_receipt.py
@@ -181,3 +181,13 @@ def test_empty_object_works():
     assert receipt.total_tax.value is None
 
 
+def test_null_tax_rates_dont_raise():
+    invoice = Receipt(
+        locale="fr",
+        total_incl=12,
+        total_excl=15,
+        taxes={(1, 0), (2, 20)},
+        orientation=0,
+        total_tax=3
+    )
+    assert invoice.checklist["taxes_match_total_incl"] is False

--- a/tests/documents/test_receipt.py
+++ b/tests/documents/test_receipt.py
@@ -179,3 +179,5 @@ def test_compare_4(receipt_object_from_scratch):
 def test_empty_object_works():
     receipt = Receipt()
     assert receipt.total_tax.value is None
+
+


### PR DESCRIPTION
# PR Details

Fixing [issue #2](https://github.com/publicMindee/mindee-api-python/issues/2)

## Description

There was no check ensuring that tax rates were non null before using them in reconstruction method.
 

## Related Issue

https://github.com/publicMindee/mindee-api-python/issues/2

## How Has This Been Tested

Added test for Invoice and Receipt classes, by constructing objects with null rates and testing 
the constructions don't raise an error.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] I have added type hints (flow) to cover my changes.
- [x] All new and existing tests passed.