### PR TITLE
chg: :sparkles: Invoice total tax better coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Mindee python SDK
 
+## v1.1.1 (2020-01-31)
+
+### Chg
+
+* Updated total tax reconstruction for invoice
+
 ## v1.1.0 (2020-12-02)
 
 ### Chg


### PR DESCRIPTION
# PR Details

Total tax reconstruction now uses also total including and total excluding for invoice

## Description

We were using only the tax lines for reconstructing the total tax. In case there is no tax line in the invoice we can use the data for total including and excluding to retrieve the information.

## How Has This Been Tested

Fully tested, as part as the invoice testing.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
